### PR TITLE
Fixes wording: s/running pkg in/running pkg install/

### DIFF
--- a/command-not-found.cpp
+++ b/command-not-found.cpp
@@ -188,7 +188,7 @@ int main(int argc, const char *argv[]) {
       cerr << " pkg install " << it->first;
       if (it->second.repository != "" &&
           !file_exists(sources_prefix + it->second.repository + ".list")) {
-        cerr << ", after running pkg in " << it->second.repository << "-repo" << endl;
+        cerr << ", after running pkg install " << it->second.repository << "-repo" << endl;
       } else {
         cerr << endl;
       }


### PR DESCRIPTION
I did not understand "The program Xvfb is not installed. Install it by executing:
 pkg install xorg-server-xvfb, after running pkg in x11-repo"

This is because, insteand of interpreting "in x11-repo" as "install x11-repo", I interpreted it as "inside the folder x11-repo".